### PR TITLE
allow no logging during test run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phlop"
-version = "0.0.12"
+version = "0.0.13"
 
 dependencies = [
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="phlop",
-    version="0.0.12",
+    version="0.0.13",
     cmdclass={},
     classifiers=[],
     include_package_data=True,


### PR DESCRIPTION
v0.0.13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a `--nolog` command-line argument to disable logging of test outputs to disk.
- **Bug Fixes**
	- Ensured parent directories are created for log files if needed.
- **Chores**
	- Updated the application version to 0.0.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->