### PR TITLE
reverse order tests

### DIFF
--- a/phlop/run/test_cases.py
+++ b/phlop/run/test_cases.py
@@ -29,6 +29,7 @@ def cli_args_parser():
         dump="Dump discovered tests as YAML, no execution",
         load="Run tests exported from dump",
         regex="Filter out non-matching execution strings",
+        reverse="reverse order - higher core count tests preferred",
         logging="0=off, 1=on non zero exit code, 2=always",
     )
 
@@ -48,6 +49,9 @@ def cli_args_parser():
     )
     parser.add_argument("--load", default=None, help=_help.load)
     parser.add_argument("-r", "--regex", default=None, help=_help.regex)
+    parser.add_argument(
+        "-R", "--reverse", action="store_true", default=False, help=_help.reverse
+    )
     parser.add_argument("--logging", type=int, default=1, help=_help.logging)
 
     return parser
@@ -152,6 +156,9 @@ def main():
             test_batches = noLog(test_batches)
         else:
             test_batches = log(test_batches)
+
+        if cli_args.reverse:
+            test_batches = list(reversed(test_batches))
 
         pp.process(
             test_batches,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "phlop"
-version = "0.0.21"
+version = "0.0.22"
 
 dependencies = [
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="phlop",
-    version="0.0.21",
+    version="0.0.22",
     cmdclass={},
     classifiers=[],
     include_package_data=True,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a `--reverse` command-line argument to reverse the order of test execution, prioritizing tests with higher core counts.

- **Chores**
  - Updated project version from "0.0.21" to "0.0.22".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->